### PR TITLE
Whitelisted WS method, fixing issue that WS connection hang up before ev...

### DIFF
--- a/csrf.go
+++ b/csrf.go
@@ -21,7 +21,7 @@ var (
 	errNoReferer  = "REVEL_CSRF: A secure request contained no Referer or its value was malformed."
 	errBadReferer = "REVEL_CSRF: Same-origin policy failure."
 	errBadToken   = "REVEL_CSRF: tokens mismatch."
-	safeMethods   = regexp.MustCompile("^(GET|HEAD|OPTIONS|TRACE)$")
+	safeMethods   = regexp.MustCompile("^(GET|HEAD|OPTIONS|TRACE|WS)$")
 )
 
 var CSRFFilter = func(c *revel.Controller, fc []revel.Filter) {


### PR DESCRIPTION
Took me 30 minutes to troubleshoot this problem. Revel use "WS" as method name of WebSocket requests, and we do not want to check CSRF token on WebSocket connection. 
